### PR TITLE
Close the room when the last user leaves (remove all cached data, etc.)

### DIFF
--- a/server/SyncServer.js
+++ b/server/SyncServer.js
@@ -46,6 +46,10 @@ class SyncServer {
             transport.to(room).emit(COMMANDS.updateUsers, users);
         });
 
+        userService.on(UserService.EVENTS.ROOM_EMPTY, (room) => {
+            syncService.close(room);
+        });
+
         this.transport.on("connection", (connection) => this.joinUser(connection, auth));
     }
 


### PR DESCRIPTION
Closes the sync service room when the last user leaves, so that a fresh copy of the data is pulled from the adapter when a user joins again.